### PR TITLE
Add /sso to paths.txt wordlist

### DIFF
--- a/paths.txt
+++ b/paths.txt
@@ -41,6 +41,7 @@
 /Rpc/
 /RpcWithCert/
 /scheduler
+/sso
 /Ucwa
 /UnifiedMessaging/
 /WebTicket


### PR DESCRIPTION
`/sso` is a generic URL route which may support NTLM authentication.
